### PR TITLE
Initialize Next.js skeleton with auth pages

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+NEXT_PUBLIC_SUPABASE_URL=https://YOUR-SUPABASE-URL.supabase.co
+NEXT_PUBLIC_SUPABASE_ANON_KEY=public-anon-key
+RESEND_API_KEY=your-resend-key
+DATABASE_URL=postgresql://postgres:YOUR_PASSWORD@db.zuipckenhdcbzhtyjhpl.supabase.co:5432/postgres

--- a/README.md
+++ b/README.md
@@ -1,1 +1,11 @@
 # Bedrock
+
+This project aims to build a full-featured Notion clone using Next.js and Supabase.
+
+## Development
+
+1. Copy `.env.example` to `.env.local` and fill in your Supabase and Resend credentials.
+2. Install dependencies with `npm install` (requires internet access).
+3. Run the development server with `npm run dev`.
+
+The current version includes a simple homepage and basic authentication forms for login and registration using Supabase and Resend.

--- a/__tests__/placeholder.test.ts
+++ b/__tests__/placeholder.test.ts
@@ -1,0 +1,3 @@
+it('placeholder test', () => {
+  expect(1 + 1).toBe(2);
+});

--- a/app/auth/login/page.tsx
+++ b/app/auth/login/page.tsx
@@ -1,0 +1,44 @@
+'use client';
+
+import { useState } from 'react';
+import { supabase } from '../../lib/supabase';
+
+export default function Login() {
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const { error } = await supabase.auth.signInWithPassword({ email, password });
+    if (error) {
+      setError(error.message);
+    } else {
+      location.href = '/';
+    }
+  };
+
+  return (
+    <div className="flex min-h-screen items-center justify-center p-8">
+      <form onSubmit={handleSubmit} className="w-full max-w-sm space-y-4">
+        <h2 className="text-2xl font-bold">Login</h2>
+        <input
+          className="w-full border p-2"
+          placeholder="Email"
+          type="email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+        />
+        <input
+          className="w-full border p-2"
+          placeholder="Password"
+          type="password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+        />
+        {error && <p className="text-red-500">{error}</p>}
+        <button className="w-full bg-black p-2 text-white" type="submit">Login</button>
+      </form>
+    </div>
+  );
+}

--- a/app/auth/register/page.tsx
+++ b/app/auth/register/page.tsx
@@ -1,0 +1,51 @@
+'use client';
+
+import { useState } from 'react';
+import { supabase } from '../../lib/supabase';
+import { resend } from '../../lib/resend';
+
+export default function Register() {
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const { error } = await supabase.auth.signUp({ email, password });
+    if (error) {
+      setError(error.message);
+    } else {
+      await resend.emails.send({
+        from: 'onboarding@bedrock.app',
+        to: email,
+        subject: 'Welcome to Bedrock',
+        html: '<p>Thanks for registering!</p>',
+      });
+      location.href = '/auth/login';
+    }
+  };
+
+  return (
+    <div className="flex min-h-screen items-center justify-center p-8">
+      <form onSubmit={handleSubmit} className="w-full max-w-sm space-y-4">
+        <h2 className="text-2xl font-bold">Register</h2>
+        <input
+          className="w-full border p-2"
+          placeholder="Email"
+          type="email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+        />
+        <input
+          className="w-full border p-2"
+          placeholder="Password"
+          type="password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+        />
+        {error && <p className="text-red-500">{error}</p>}
+        <button className="w-full bg-black p-2 text-white" type="submit">Register</button>
+      </form>
+    </div>
+  );
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,0 +1,18 @@
+import './globals.css';
+import type { Metadata } from 'next';
+import { Inter } from 'next/font/google';
+
+const inter = Inter({ subsets: ['latin'] });
+
+export const metadata: Metadata = {
+  title: 'Bedrock',
+  description: 'Notion clone built with Next.js and Supabase',
+};
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="en">
+      <body className={inter.className}>{children}</body>
+    </html>
+  );
+}

--- a/app/lib/resend.ts
+++ b/app/lib/resend.ts
@@ -1,0 +1,3 @@
+import { Resend } from 'resend';
+
+export const resend = new Resend(process.env.RESEND_API_KEY!);

--- a/app/lib/supabase.ts
+++ b/app/lib/supabase.ts
@@ -1,0 +1,6 @@
+import { createClient } from '@supabase/supabase-js';
+
+export const supabase = createClient(
+  process.env.NEXT_PUBLIC_SUPABASE_URL!,
+  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
+);

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,0 +1,7 @@
+export default function Home() {
+  return (
+    <main className="flex min-h-screen flex-col items-center justify-center p-24">
+      <h1 className="text-4xl font-bold">Welcome to Bedrock</h1>
+    </main>
+  );
+}

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,5 @@
+/** @type {import('ts-jest').JestConfigWithTsJest} */
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+};

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,6 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+/// <reference types="next/navigation-types/compat/navigation" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/next.config.js
+++ b/next.config.js
@@ -1,0 +1,9 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+  experimental: {
+    appDir: true
+  }
+};
+
+module.exports = nextConfig;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "bedrock",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "test": "jest"
+  },
+  "dependencies": {
+    "next": "14.2.1",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "@supabase/supabase-js": "2.39.8",
+    "resend": "0.25.0"
+  },
+  "devDependencies": {
+    "typescript": "5.4.5",
+    "@types/react": "18.2.45",
+    "@types/node": "20.11.30",
+    "jest": "29.7.0",
+    "ts-jest": "29.1.1"
+  }
+}

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,12 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: [
+    './app/**/*.{js,ts,jsx,tsx}',
+    './components/**/*.{js,ts,jsx,tsx}'
+  ],
+  darkMode: 'class',
+  theme: {
+    extend: {}
+  },
+  plugins: []
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- set up Next.js project skeleton with TypeScript
- add Tailwind CSS config and global styles
- add Supabase and Resend helpers
- create login and register pages
- provide example environment variables
- add placeholder Jest test

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841bdec9b6483299597fd52e8d20be0