### PR TITLE
Fix ThemeToggle component import

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,7 @@
 import '../styles/globals.css';
 import type { Metadata } from 'next';
 import { Inter } from 'next/font/google';
+import ThemeToggle from '../components/theme-toggle';
 
 
 const inter = Inter({ subsets: ['latin'] });


### PR DESCRIPTION
## Summary
- import `ThemeToggle` in the root layout to avoid runtime error

## Testing
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841ef2cf31083299cbc471a85956ad4