### PR TITLE
Implement home page with auth links and tailwind setup

### DIFF
--- a/app/auth/login/page.tsx
+++ b/app/auth/login/page.tsx
@@ -1,7 +1,9 @@
 'use client';
 
 import { useState } from 'react';
+import Link from 'next/link';
 import { supabase } from '../../lib/supabase';
+import { Button } from '../../../components/ui/button';
 
 export default function Login() {
   const [email, setEmail] = useState('');
@@ -37,7 +39,15 @@ export default function Login() {
           onChange={(e) => setPassword(e.target.value)}
         />
         {error && <p className="text-red-500">{error}</p>}
-        <button className="w-full bg-black p-2 text-white" type="submit">Login</button>
+        <Button className="w-full" type="submit">
+          Login
+        </Button>
+        <p className="text-sm text-center">
+          No account?{' '}
+          <Link href="/auth/register" className="underline">
+            Register
+          </Link>
+        </p>
       </form>
     </div>
   );

--- a/app/auth/register/page.tsx
+++ b/app/auth/register/page.tsx
@@ -1,8 +1,10 @@
 'use client';
 
 import { useState } from 'react';
+import Link from 'next/link';
 import { supabase } from '../../lib/supabase';
 import { resend } from '../../lib/resend';
+import { Button } from '../../../components/ui/button';
 
 export default function Register() {
   const [email, setEmail] = useState('');
@@ -44,7 +46,15 @@ export default function Register() {
           onChange={(e) => setPassword(e.target.value)}
         />
         {error && <p className="text-red-500">{error}</p>}
-        <button className="w-full bg-black p-2 text-white" type="submit">Register</button>
+        <Button className="w-full" type="submit">
+          Register
+        </Button>
+        <p className="text-sm text-center">
+          Already have an account?{' '}
+          <Link href="/auth/login" className="underline">
+            Login
+          </Link>
+        </p>
       </form>
     </div>
   );

--- a/app/lib/resend.ts
+++ b/app/lib/resend.ts
@@ -1,7 +1,3 @@
 import { Resend } from 'resend';
 
-codex/create-bedrock-–-notion-clone-in-next.js
-
-
 export const resend = new Resend(process.env.RESEND_API_KEY!);
-main

--- a/app/lib/utils.ts
+++ b/app/lib/utils.ts
@@ -1,0 +1,3 @@
+export function cn(...classes: (string | false | null | undefined)[]) {
+  return classes.filter(Boolean).join(' ');
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,7 +1,18 @@
+import Link from 'next/link';
+import { Button } from '../components/ui/button';
+
 export default function Home() {
   return (
-    <main className="flex min-h-screen flex-col items-center justify-center p-24">
+    <main className="flex min-h-screen flex-col items-center justify-center space-y-6 p-24">
       <h1 className="text-4xl font-bold">Welcome to Bedrock</h1>
+      <div className="space-x-4">
+        <Link href="/auth/login">
+          <Button>Login</Button>
+        </Link>
+        <Link href="/auth/register">
+          <Button variant="outline">Register</Button>
+        </Link>
+      </div>
     </main>
   );
 }

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -1,0 +1,30 @@
+import { cn } from '../../app/lib/utils';
+import { forwardRef } from 'react';
+
+export interface ButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: 'default' | 'outline';
+}
+
+const baseClasses =
+  'inline-flex items-center justify-center rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50';
+
+const variants: Record<string, string> = {
+  default: 'bg-black text-white hover:bg-black/90',
+  outline: 'border border-input bg-white hover:bg-gray-100',
+};
+
+const Button = forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ className, variant = 'default', ...props }, ref) => {
+    return (
+      <button
+        ref={ref}
+        className={cn(baseClasses, variants[variant], className)}
+        {...props}
+      />
+    );
+  }
+);
+Button.displayName = 'Button';
+
+export { Button };

--- a/package.json
+++ b/package.json
@@ -20,6 +20,9 @@
     "@types/react": "18.2.45",
     "@types/node": "20.11.30",
     "jest": "29.7.0",
-    "ts-jest": "29.1.1"
+    "ts-jest": "29.1.1",
+    "tailwindcss": "3.4.4",
+    "postcss": "8.4.38",
+    "autoprefixer": "10.4.19"
   }
 }

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};


### PR DESCRIPTION
## Summary
- create reusable Button component (shadcn-style) and cn utility
- add login and registration pages with Button component and links between them
- clean up Resend client implementation
- build simple home page with Login/Register buttons
- configure Tailwind and PostCSS dependencies

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6841efbcd7108329861e703813f4535b